### PR TITLE
Implement "re-move" without undo

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -53,6 +53,7 @@
 .square::before {
 	position: absolute;
 	top: 0px;
+	box-sizing: border-box;
 	width: 100%;
 	height: 100%;
 	opacity: 75%;
@@ -80,19 +81,20 @@
 .move-range:hover::before {
 	background-color: skyblue;
 }
+.move-origin::before {
+	border: 8px solid skyblue;
+}
 .skill-range::before {
 	background-color: orange;
 }
 .skill-range:hover::before {
 	background-color: yellow;
 }
+.skill-aoe::before {
+	border: 8px solid yellow;
+}
 .skill-range-invalid::before {
 	background-color: darkgoldenrod;
-}
-
-.skill-aoe::before {
-	box-sizing: border-box;
-	border: 4px solid black;
 }
 
 .piece {

--- a/js/container.js
+++ b/js/container.js
@@ -247,12 +247,12 @@ class Board extends Container {
 		square.inRange = true;
 	}
 	setMoveArea(piece) {
-		if (!piece || !piece.square || piece.square.parent != this) return;
+		if (!piece || !piece.moveRange) return;
 
-		if (!piece.moveRange) return;
+		var origin = piece.moved ? piece.originSquare : piece.square;
+		if (!origin || origin.parent != this) return;
 
-		var origin = piece.square;
-		this._paintMoveRange(origin, piece.moveRange);
+		this._paintMoveRange(origin, piece.moveRange, true);
 		var edges = [origin];
 		
 		for (var i = 0; i < edges.length; i++) {
@@ -273,8 +273,9 @@ class Board extends Container {
 			}
 		}
 	}
-	_paintMoveRange(square, movesLeft) {
+	_paintMoveRange(square, movesLeft, isOrigin) {
 		square.el.classList.add('move-range');
+		if (isOrigin) square.el.classList.add('move-origin');
 		square.el.ondragover = this._allowDrop;
 		square.inRange = true;
 		square.movesLeft = movesLeft;
@@ -308,6 +309,7 @@ class Board extends Container {
 	_clearPaint(square) {
 		square.el.classList.remove('deploy-range');
 		square.el.classList.remove('move-range');
+		square.el.classList.remove('move-origin');
 		square.el.classList.remove('skill-range');
 		square.el.classList.remove('skill-range-invalid');
 		square.el.ondragover = null;

--- a/js/piece.js
+++ b/js/piece.js
@@ -244,8 +244,7 @@ class ControllablePiece extends TargetablePiece {
 	}
 
 	get moveRange() {
-		if (this.moved) return 0;
-		else return this._moveRange;
+		return this._moveRange;
 	}
 
 	get skills() {
@@ -260,29 +259,34 @@ class ControllablePiece extends TargetablePiece {
 		this.myTurn = false;
 		this.moved = false;
 		this.acted = false;
-		this._startSquare = null;
+		this.originSquare = null;
 		this._skills.forEach(skill => skill.endTurn());
 		this.refresh();
 	}
 
 	move(target) {
-		if (this.moved || this.square == target) return false;
+		if (this.square == target) return false;
 
 		var oldSquare = this.square;
 		if (target.parent.movePiece(this, target)) {
-			this.moved = true;
-			this._startSquare = oldSquare;
+			if (!this.moved) {
+				this.moved = true;
+				this.originSquare = oldSquare;
+			} else if (target == this.originSquare) {
+				this.moved = false;
+				this.originSquare = null;
+			}
 			this.refresh();
 			return true;
 		}
 		return false;
 	}
 	undoMove() {
-		if (!this.moved || !this._startSquare) return false;
+		if (!this.moved || !this.originSquare) return false;
 		
-		if (this._startSquare.parent.movePiece(this, this._startSquare)) {
+		if (this.originSquare.parent.movePiece(this, this.originSquare)) {
 			this.moved = false;
-			this._startSquare = null;
+			this.originSquare = null;
 			this.refresh();
 			return true;
 		}

--- a/js/scene.js
+++ b/js/scene.js
@@ -331,7 +331,9 @@ class BattleScene extends Scene {
 			if (this._target) {
 				this._board.showAoE(this._skill, this._target);
 			}
-		} else if (this._unit && (!this._unit.moved || this._lastMove == this._unit)) {
+		} else if (this._unit && !this._unit.moved) {
+			this._board.setMoveArea(this._unit);
+		} else if (this._unit && this._lastMove == this._unit && this._dragging) {
 			this._board.setMoveArea(this._unit);
 		}
 	}
@@ -368,6 +370,7 @@ class BattleScene extends Scene {
 				}
 			}
 		}
+		this._dragging = dragging;
 		this.refresh();
 	}
 	selectPosition(square, dragId) {
@@ -392,6 +395,7 @@ class BattleScene extends Scene {
 				this._moveUnit(this._unit, square);
 			}
 		}
+		this._dragging = false;
 		this.refresh();
 	}
 


### PR DESCRIPTION
You can move the most recent unit around within its move range without needing to hit "undo."